### PR TITLE
Throw warning, not error, when can't download avatar from external

### DIFF
--- a/src/AvatarManager.php
+++ b/src/AvatarManager.php
@@ -174,7 +174,7 @@ class AvatarManager implements AvatarManagerInterface {
         catch (\Exception $e) {
           $this->loggerFactory
             ->get('avatars')
-            ->error($this->t('Failed to get @id avatar for @generator: %exception', [
+            ->warning($this->t('Failed to get @id avatar for @generator: %exception', [
               '@id' => $user->id(),
               '@generator' => $avatar_generator->id(),
               '%exception' => $e->getMessage(),


### PR DESCRIPTION
When using an external service such as gravatar, a response code != `200` is a common response. This does not, however, constitute an error. It just means the service can't provide an avatar.

For admins monitoring true site "errors," throwing an error in such a case is overkill. This is more like a warning, or perhaps even a notice?
