### PR TITLE
Add helper to determine if a file is an avatar preview

### DIFF
--- a/avatars.module
+++ b/avatars.module
@@ -132,20 +132,17 @@ function avatars_entity_update(EntityInterface $entity) {
 
 /**
  * Implements hook_ENTITY_TYPE_storage_load().
+ *
+ * Add cache tags to avatar preview files. These tags will be added when image
+ * formatters are rendered.
  */
 function avatars_file_storage_load(array $entities) {
   /** @var $entities \Drupal\file\FileInterface[] */
-  $avatar_preview_storage = \Drupal::entityManager()
-    ->getStorage('avatars_preview');
+  /** @var \Drupal\avatars\AvatarManager $avatar_manager */
+  $avatar_manager = \Drupal::service('avatars.avatar_manager');
 
-  // Add cache tags to avatar preview files. These tags will be added when image
-  // formatters are rendered.
   foreach ($entities as $file) {
-    $avatar_previews = $avatar_preview_storage->loadByProperties([
-      'avatar' => $file->id(),
-    ]);
-    if ($avatar_preview = reset($avatar_previews)) {
-      /** @var AvatarPreviewInterface $avatar_preview */
+    if (FALSE !== $avatar_manager->getAvatarPreviewByFile($file)) {
       $file->addCacheTags(['avatar_preview']);
     }
   }

--- a/avatars.services.yml
+++ b/avatars.services.yml
@@ -1,7 +1,7 @@
 services:
   avatars.avatar_manager:
     class: Drupal\avatars\AvatarManager
-    arguments: ['@config.factory', '@http_client', '@cache_tags.invalidator', '@logger.factory', '@entity_type.manager', '@plugin.manager.avatar_generator']
+    arguments: ['@config.factory', '@http_client', '@cache_tags.invalidator', '@logger.factory', '@entity_type.manager', '@file.usage', '@plugin.manager.avatar_generator']
     parent: container.trait
   plugin.manager.avatar_generator:
     class: Drupal\avatars\AvatarGeneratorPluginManager

--- a/src/AvatarManager.php
+++ b/src/AvatarManager.php
@@ -13,6 +13,7 @@ use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\file\FileUsage\FileUsageInterface;
 use Drupal\file\FileInterface;
 use Drupal\user\UserInterface;
 use GuzzleHttp\ClientInterface;
@@ -56,6 +57,13 @@ class AvatarManager implements AvatarManagerInterface {
   protected $loggerFactory;
 
   /**
+   * The file usage service
+   *
+   * @var \Drupal\file\FileUsage\FileUsageInterface
+   */
+  protected $fileUsage;
+
+  /**
    * Storage for avatar generator storage entities.
    *
    * @var \Drupal\avatars\AvatarGeneratorStorageInterface
@@ -82,16 +90,19 @@ class AvatarManager implements AvatarManagerInterface {
    *   The logger channel factory.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
+   * @param \Drupal\file\FileUsage\FileUsageInterface $file_usage
+   *   The file usage service.
    * @param \Drupal\avatars\AvatarGeneratorPluginManagerInterface $avatar_generator
    *   The avatar generator plugin manager.
    */
-  function __construct(ConfigFactoryInterface $config_factory, ClientInterface $http_client, CacheTagsInvalidatorInterface $cache_tag_invalidator, LoggerChannelFactoryInterface $logger_factory, EntityTypeManagerInterface $entity_type_manager, AvatarGeneratorPluginManagerInterface $avatar_generator) {
+  function __construct(ConfigFactoryInterface $config_factory, ClientInterface $http_client, CacheTagsInvalidatorInterface $cache_tag_invalidator, LoggerChannelFactoryInterface $logger_factory, EntityTypeManagerInterface $entity_type_manager, FileUsageInterface $file_usage, AvatarGeneratorPluginManagerInterface $avatar_generator) {
     $this->configFactory = $config_factory;
     $this->httpClient = $http_client;
     $this->cacheTagInvalidator = $cache_tag_invalidator;
     $this->loggerFactory = $logger_factory;
     $this->avatarGeneratorStorage = $entity_type_manager
       ->getStorage('avatar_generator');
+    $this->fileUsage = $file_usage;
     $this->avatarGenerator = $avatar_generator;
   }
 
@@ -189,10 +200,19 @@ class AvatarManager implements AvatarManagerInterface {
     if (!$file && $url = $plugin->generateUri($user)) {
       $directory = 'public://avatar_kit/' . $avatar_generator->id();
       if (file_prepare_directory($directory, FILE_CREATE_DIRECTORY)) {
+//        throw new \Exception(drupal_realpath($directory));
+//        debug($url);
+//        debug(getenv('SIMPLETEST_BASE_URL'));
+        debug(\Drupal\Core\Url::fromRoute('avatars_test.image', [], ['absolute' => TRUE])
+          ->toString());
         try {
           if (($result = $this->httpClient->get($url)) && ($result->getStatusCode() == 200)) {
+            debug($result);
             $file_path = $directory . '/' . $user->id() . '.jpg';
             $file = file_save_data($result->getBody(), $file_path, FILE_EXISTS_REPLACE);
+          }
+          else {
+            throw new \Exception('wutface.');
           }
         }
         catch (ClientException $e) {
@@ -200,6 +220,7 @@ class AvatarManager implements AvatarManagerInterface {
           return FALSE;
         }
         catch (\Exception $e) {
+          debug('xx' . $e->getMessage());
           $this->loggerFactory
             ->get('avatars')
             ->error($this->t('Failed to get @id avatar for @generator: %exception', [
@@ -209,6 +230,9 @@ class AvatarManager implements AvatarManagerInterface {
             ]));
           return FALSE;
         }
+      }
+      else {
+        throw new \Exception('Cannot create avatar kit directory.');
       }
     }
 
@@ -276,6 +300,21 @@ class AvatarManager implements AvatarManagerInterface {
       $avatar_generators[] = $avatar_generator;
     }
     return $avatar_generators;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  function getAvatarPreviewByFile(FileInterface $file) {
+    $usages = $this->fileUsage->listUsage($file);
+
+    if (isset($usages['avatars']['avatars_preview'])) {
+      $avatar_previews = array_keys($usages['avatars']['avatars_preview']);
+      // Return the first key, there should only ever be one.
+      return reset($avatar_previews);
+    }
+
+    return FALSE;
   }
 
 }

--- a/src/AvatarManagerInterface.php
+++ b/src/AvatarManagerInterface.php
@@ -8,6 +8,7 @@
 namespace Drupal\avatars;
 
 use Drupal\user\UserInterface;
+use Drupal\file\FileInterface;
 
 /**
  * Provides an interface to the avatar manager service.
@@ -122,5 +123,17 @@ interface AvatarManagerInterface {
    *   An array of avatar generator entities.
    */
   function getAvatarGeneratorsForUser(UserInterface $user, $exclude_user_preference = TRUE);
+
+  /**
+   * Determines if a file entity is an avatar preview.
+   *
+   * @param \Drupal\file\FileInterface $file
+   *   The file entity to check.
+   *
+   * @return int|FALSE
+   *   Returns the avatar preview entity ID, or FALSE if the file is not a
+   *   avatar preview.
+   */
+  function getAvatarPreviewByFile(FileInterface $file);
 
 }

--- a/src/Entity/AvatarPreview.php
+++ b/src/Entity/AvatarPreview.php
@@ -176,8 +176,8 @@ class AvatarPreview extends ContentEntityBase implements AvatarPreviewInterface 
 
     if (!$update && $this->getAvatar()) {
       /** @var \Drupal\file\FileUsage\FileUsageInterface $file_usage */
-      $file_usage = \Drupal::service('file.usage')
-        ->add($this->getAvatar(), 'avatars', $this->getEntityTypeId(), $this->id());
+      $file_usage = \Drupal::service('file.usage');
+      $file_usage->add($this->getAvatar(), 'avatars', $this->getEntityTypeId(), $this->id());
     }
   }
 

--- a/src/Tests/AvatarKitGeneratorTest.php
+++ b/src/Tests/AvatarKitGeneratorTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\avatars\Tests;
 
 use Drupal\avatars\Entity\AvatarGenerator;
+use Drupal\file\Entity\File;
 use Drupal\user\Entity\Role;
 use Drupal\user\Entity\User;
 use Drupal\user\RoleInterface;
@@ -63,4 +64,61 @@ class AvatarKitGeneratorTest extends AvatarKitWebTestBase {
     $am = \Drupal::service('avatars.avatar_manager');
     $am->syncAvatar($anonymous);
   }
+
+  /**
+   * Tests whether a file is matched with an avatar preview.
+   *
+   * Tests AvatarManagerInterface::getAvatarPreviewByFile()
+   */
+  public function testFileIsAvatarPreview() {
+    $generator_2 = AvatarGenerator::create([
+      'label' => $this->randomMachineName(),
+      'id' => $this->randomMachineName(),
+      'plugin' => 'avatars_test_static',
+    ]);
+    $generator_2
+      ->setStatus(TRUE)
+      ->save();
+
+    $user = $this->createUser([
+      'avatars avatar_generator user ' . $generator_2->id(),
+    ]);
+
+    /** @var \Drupal\avatars\AvatarManagerInterface $am */
+    $am = \Drupal::service('avatars.avatar_manager');
+    $avatar_preview = $am->findValidAvatar($user);
+    $file = $avatar_preview->getAvatar();
+
+    $this->assertIdentical($avatar_preview->id(), $am->getAvatarPreviewByFile($file));
+  }
+
+  /**
+   * Tests whether a file is not matched with an avatar preview.
+   *
+   * Tests AvatarManagerInterface::getAvatarPreviewByFile()
+   */
+  public function testFileNotAvatarPreview() {
+    $generator_2 = AvatarGenerator::create([
+      'label' => $this->randomMachineName(),
+      'id' => $this->randomMachineName(),
+      'plugin' => 'avatars_test_static',
+    ]);
+    $generator_2
+      ->setStatus(TRUE)
+      ->save();
+
+    $user = $this->createUser([
+      'avatars avatar_generator user ' . $generator_2->id(),
+    ]);
+
+
+    /** @var \Drupal\avatars\AvatarManagerInterface $am */
+    $am = \Drupal::service('avatars.avatar_manager');
+
+    // Create a random file.
+    $file = file_save_data($this->randomString());
+
+    $this->assertFalse($am->getAvatarPreviewByFile($file));
+  }
+
 }

--- a/src/Tests/AvatarKitGeneratorTest.php
+++ b/src/Tests/AvatarKitGeneratorTest.php
@@ -89,7 +89,7 @@ class AvatarKitGeneratorTest extends AvatarKitWebTestBase {
     $avatar_preview = $am->findValidAvatar($user);
     $file = $avatar_preview->getAvatar();
 
-    $this->assertIdentical($avatar_preview->id(), $am->getAvatarPreviewByFile($file));
+    $this->assertEqual($avatar_preview->id(), $am->getAvatarPreviewByFile($file));
   }
 
   /**

--- a/tests/src/Kernel/AvatarKitPermissionsTest.php
+++ b/tests/src/Kernel/AvatarKitPermissionsTest.php
@@ -19,8 +19,7 @@ class AvatarKitPermissionsTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = ['avatars', 'user', 'avatars_test', 'system'];
-
+  public static $modules = ['avatars', 'user', 'avatars_test', 'system', 'file'];
 
   /**
    * The permissions handler


### PR DESCRIPTION
Reworked hook_file_storage_load() so it would not cause recursion, especially when used simultaneously with file_entity module.
Added getAvatarPreviewByFile() helper to Avatar Manager to determine if a file is associated with an avatar preview entity.
Added tests for getAvatarPreviewByFile() helper.

See dpi/avatars#28
See dpi/avatars#31
